### PR TITLE
Integration with new iam endpoint

### DIFF
--- a/keystoneclient/middleware/auth_token.py
+++ b/keystoneclient/middleware/auth_token.py
@@ -234,7 +234,7 @@ opts = [
                 help='Do not handle authorization requests within the'
                 ' middleware, but delegate the authorization decision to'
                 ' downstream WSGI components'),
-    cfg.IntOpt('http_connect_timeout',
+    cfg.BoolOpt('http_connect_timeout',
                 default=None,
                 help='Request timeout value for communicating with Identity'
                 ' API server.'),

--- a/keystoneclient/middleware/auth_token.py
+++ b/keystoneclient/middleware/auth_token.py
@@ -813,7 +813,6 @@ class AuthProtocol(object):
         kwargs['verify'] = self.ssl_ca_file or True
         if self.ssl_insecure:
             kwargs['verify'] = False
-        kwargs['verify'] = False
 
         RETRIES = self.http_request_max_retries
         retry = 0

--- a/keystoneclient/middleware/auth_token.py
+++ b/keystoneclient/middleware/auth_token.py
@@ -820,7 +820,6 @@ class AuthProtocol(object):
             try:
                 print(url, method, kwargs)
                 response = requests.request(method, url, **kwargs)
-                self.LOG.info(response.text)
                 break
             except Exception as e:
                 if retry >= RETRIES:

--- a/keystoneclient/middleware/auth_token.py
+++ b/keystoneclient/middleware/auth_token.py
@@ -818,7 +818,6 @@ class AuthProtocol(object):
         retry = 0
         while True:
             try:
-                print(url, method, kwargs)
                 response = requests.request(method, url, **kwargs)
                 break
             except Exception as e:
@@ -943,11 +942,6 @@ class AuthProtocol(object):
         :raise InvalidUserToken when unable to parse token object
 
         """
-        #auth_ref = access.AccessInfo.factory(body=token_info)
-        #roles = ','.join(auth_ref.role_names)
-
-        #if _token_is_v2(token_info) and not auth_ref.project_id:
-        #    raise InvalidUserToken('Unable to determine tenancy.')
 
         rval = {
             'X-Identity-Status': 'Confirmed',
@@ -958,13 +952,7 @@ class AuthProtocol(object):
         }
 
         self.LOG.debug('Received request from user: %s with project_id : %s',
-                       token_info.get('user_id'), token_info.get('domain_id'))
-
-#        if self.include_service_catalog and auth_ref.has_service_catalog():
-#            catalog = auth_ref.service_catalog.get_data()
-#            if _token_is_v3(token_info):
-#                catalog = _v3_to_v2_catalog(catalog)
-#            rval['X-Service-Catalog'] = jsonutils.dumps(catalog)
+                       token_info.get('user_id'), token_info.get('account_id'))
 
         return rval
 
@@ -1084,7 +1072,6 @@ class AuthProtocol(object):
         if not self.auth_version:
             self.auth_version = self._choose_api_version()
         self.auth_version = self.auth_version.lower()
-        self.LOG.warn(self.auth_version)
         if self.auth_version == 'v3' or self.auth_version == 'v3.0':
             headers = {'X-Auth-Token': safe_quote(user_token)}
             path = '/v3/auth/tokens'


### PR DESCRIPTION
Changed keystoneclient middleware in place of keystonemiddleware to integrate with new IAM.

This was done because changes in keystonemiddleware were more involved.

Tested 
1. DescribeInstanceTypes
2. DescribeImages, 
3. DescribeKeyPairs
4. CreateKeyPair
5. DeleteKeyPair

with the changes.
